### PR TITLE
20.04で動かしてみた

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:18.04
+FROM ubuntu:20.04
 
 ENV HOME=/root \
     DEBIAN_FRONTEND=noninteractive \
@@ -10,9 +10,22 @@ RUN ln -snf /usr/share/zoneinfo/$TZ /etc/localtime && \
     echo $TZ > /etc/timezone
 
 # Install packages
-RUN apt-get update && \
-    # Install the required packages for desktop    
-    apt-get install -y \
+RUN apt-get update
+
+# Install apt-utils
+RUN apt-get install -y apt-utils
+
+# Install japanese language packs(optional)
+RUN apt-get install -y \
+      language-pack-ja-base language-pack-ja \
+      ibus-anthy \
+      fonts-takao \
+      && \
+    echo ja_JP.UTF-8 UTF-8 >> /etc/locale.gen && \
+    dpkg-reconfigure locales
+
+# Install the required packages for desktop
+RUN apt-get install -y \
       supervisor \
       xvfb \
       xfce4 \
@@ -25,12 +38,6 @@ RUN apt-get update && \
       net-tools \
       vim-tiny \
       xfce4-terminal \
-      && \
-    # Install japanese language packs(optional)
-    apt-get install -y \
-      language-pack-ja-base language-pack-ja \
-      ibus-anthy \
-      fonts-takao \
       && \
     # Clean up
     apt-get clean && \

--- a/supervisord/desktop.conf
+++ b/supervisord/desktop.conf
@@ -26,7 +26,7 @@ stdout_logfile=/var/log/x11vnc.log
 stderr_logfile=/var/log/x11vnc.err
 
 [program:novnc]
-command=/opt/noVNC/utils/novnc_proxy --vnc localhost:8080 --listen 8080
+command=/opt/noVNC/utils/novnc_proxy --vnc localhost:5900 --listen 8080
 autorestart=true
 stdout_logfile=/var/log/novnc.log
 stderr_logfile=/var/log/novnc.err

--- a/supervisord/desktop.conf
+++ b/supervisord/desktop.conf
@@ -26,7 +26,7 @@ stdout_logfile=/var/log/x11vnc.log
 stderr_logfile=/var/log/x11vnc.err
 
 [program:novnc]
-command=/opt/noVNC/utils/launch.sh --vnc localhost:5900 --listen 8080
+command=/opt/noVNC/utils/novnc_proxy --vnc localhost:8080 --listen 8080
 autorestart=true
 stdout_logfile=/var/log/novnc.log
 stderr_logfile=/var/log/novnc.err


### PR DESCRIPTION
@uphy さま
ubuntu-desktop-jpのファイル、ありがたく活用させていただきました。  
今般、拝借＆改造により20.04での動作を行うことができ、大変助かりました。  

感謝の念より、変更内容提出します。  
（以下は動作確認時の手順を掲載します）  

---

### 20.04動作用のファイルのクローンする（20.04ブランチの中身）  

```
git clone https://github.com/JunichiWatanuki/ubuntu-desktop-jp.git
```

### 対象ファイルのディレクトリに移動する  

```
cd ubuntu-desktop-jp/
```

### ブランチ20.04へ移動する  

```
git checkout 20.04
```

### ubuntudesk2004:1 というイメージとしてビルドする（もしかしたら10分くらいかかるかも）  

```
docker build -t ubuntudesk2004:1 -f Dockerfile .
```

### noVNCをTCPポート18080番で待ち受けする状態で、コンテナを起動する  

```
docker run -itd --privileged=true --name ubuntudesk2004 -p 18080:8080 ubuntudesk2004:1 /usr/bin/supervisord
```

### 起動したコンテナのデバッグ用としてコンソールで接続する  

```
docker exec -it ubuntudesk2004:1 bash
```

### Webブラウザで、コンテナのnoVNCへ接続する  

```
http://<コンテナの待ち受けIPアドレス>:18080
```