### PR TITLE
22.04にて動作確認しました

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:20.04
+FROM ubuntu:22.04
 
 ENV HOME=/root \
     DEBIAN_FRONTEND=noninteractive \
@@ -18,7 +18,7 @@ RUN apt-get install -y apt-utils
 # Install japanese language packs(optional)
 RUN apt-get install -y \
       language-pack-ja-base language-pack-ja \
-      ibus-anthy \
+      ibus-kkc \
       fonts-takao \
       && \
     echo ja_JP.UTF-8 UTF-8 >> /etc/locale.gen && \
@@ -30,6 +30,7 @@ RUN apt-get install -y \
       xvfb \
       xfce4 \
       x11vnc \
+      dbus-x11 \
       && \
     # Install utilities(optional).
     apt-get install -y \

--- a/README.md
+++ b/README.md
@@ -55,5 +55,5 @@ $ docker run \
     -v "$(pwd)/data/config:/root/.config" \
     -v "$(pwd)/data/Desktop:/root/Desktop" \
     -p 8080:8080 \
-    uphy/ubuntu-desktop-jp:20.04
+    uphy/ubuntu-desktop-jp:22.04
 ```

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ Ubuntuデスクトップ環境を、ブラウザ上で利用することが出�
 まずはお試しで実行してみます。
 
 ```sh
-$ docker run --rm -p 8080:8080 uphy/ubuntu-desktop-jp:20.04
+$ docker run --rm -p 8080:8080 uphy/ubuntu-desktop-jp:22.04
 ```
 
 コンテナが立ち上がったら、ブラウザで[http://localhost:8080](http://localhost:8080)にアクセスしてください。


### PR DESCRIPTION
@uphy さま
ubuntu-desktop-jpのファイル、再び利用させていただきました。  
ありがとうございます。

Ubuntu24.04としても動作できましたが22.04ブランチが存在しないため、一旦Ubuntu22.04用としてプルリクを起票させていただきます。

Dockerfileの先頭行において、Ubuntuコンテナのベースイメージのバージョンを書き換えることにより、22.04としても24.04としても、いずれのバージョンでも利用できたこと申し添えます。
（必要ありましたらマージ後に改めて24.04のプルリク起票もできますし、お手元で24.04ブランチの作成をしていただくのでも問題ないと思います。ご希望に合わせたいと思います。）  

|Dockerfileの先頭行|動作するUbuntuバージョン|
|:---|:---|
|FROM ubuntu:22.04|Ubuntu 22.04|
|FROM ${\textsf{\color{red}ubuntu:24.04}}$ |Ubuntu ${\textsf{\color{red}24.04}}$|




